### PR TITLE
Se modifica DateTime.Now por DateTime.UtcNow

### DIFF
--- a/BNails_MAUI/Repositories/UsuarioRepository.cs
+++ b/BNails_MAUI/Repositories/UsuarioRepository.cs
@@ -55,17 +55,19 @@ namespace BNails_MAUI.Repositories
 
             if(reader.Read())
             {
+                int idxCodigo = reader.GetOrdinal("codigo_recuperacion");
+                int idxFecha = reader.GetOrdinal("codigo_fecha_exp");
+
                 return new Usuario
                 {
                     Id = reader.GetInt32("id"),
                     Nombre = reader.GetString("nombre"),
                     Email = reader.GetString("email"),
                     Password = reader.GetString("password"),
-                    CodigoRecuperacion = reader.IsDBNull("codigo_recuperacion") ? null : reader.GetString("codigo_recuperacion"),
-                    CodigoRecuExpira = reader.IsDBNull("codigo_fecha_exp") ? null : reader.GetDateTime("codigo_fecha_exp")
+                    CodigoRecuperacion = reader.IsDBNull(idxCodigo) ? null : reader.GetString(idxCodigo),
+                    CodigoRecuExpira = reader.IsDBNull(idxFecha) ? null : reader.GetDateTime(idxFecha).ToLocalTime()
                 };
             }
-
 
             return null;
         }

--- a/BNails_MAUI/Services/EmailService.cs
+++ b/BNails_MAUI/Services/EmailService.cs
@@ -32,10 +32,10 @@ namespace BNails_MAUI.Services
         {
             try
             {
-                var Existeusuario = _usuarioService.ExisteUsuarioPorEmail(email);
-                if(Existeusuario == null) return false;
+                bool Existeusuario = _usuarioService.ExisteUsuarioPorEmail(email);
+                if(!Existeusuario) return false;
 
-                var expiraCodigo = DateTime.Now.AddMinutes(10);
+                var expiraCodigo = DateTime.UtcNow.AddMinutes(10);
 
                 bool codigoGuardado = _usuarioService.GuardarCodigoVerificacion(email, codigoVerificacion, expiraCodigo);
 

--- a/BNails_MAUI/ViewModels/ValidarCodigoViewModel.cs
+++ b/BNails_MAUI/ViewModels/ValidarCodigoViewModel.cs
@@ -75,7 +75,7 @@ namespace BNails_MAUI.ViewModels
             if(usuario.CodigoRecuExpira < DateTime.Now)
             {
                 await _dialogService.MostrarAlertaAsync("Atención!","El código ingresado ha expirado. Por favor, volvé a solicitar el código de recuperación.");
-                await Shell.Current.GoToAsync("//RecuperarPwd");
+                await Shell.Current.GoToAsync("RecuperarPwd");
                 return;
             }
 


### PR DESCRIPTION
La modificación se realiza porque la lectura de la fecha de expiración del código para cambio de contraseña se realizaba en UTC 0 y no en UTC -3.