### PR TITLE
Se finaliza lógica completa botón Reenviar Código.

### DIFF
--- a/BNails_MAUI/App.xaml
+++ b/BNails_MAUI/App.xaml
@@ -13,7 +13,7 @@
                 <ResourceDictionary>
                     <converters:BoolToBrushConverter x:Key="BoolToBrushConverter"
                                          ActiveBrush="DarkBlue"
-                                         UnableBrush="Gray" />
+                                         UnenableBrush="Gray" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/BNails_MAUI/Converters/BoolToBrushConverter.cs
+++ b/BNails_MAUI/Converters/BoolToBrushConverter.cs
@@ -10,15 +10,15 @@ namespace BNails_MAUI.Converters
     public class BoolToBrushConverter : IValueConverter
     {
         public Brush ActiveBrush { get; set; } = Colors.DarkBlue;
-        public Brush UnableBrush { get; set; } = Colors.Gray;
+        public Brush UnenableBrush { get; set; } = Colors.Gray;
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value is bool isActive)
             {
-                return isActive ? ActiveBrush : UnableBrush;
+                return isActive ? ActiveBrush : UnenableBrush;
             }
-            return UnableBrush;
+            return UnenableBrush;
         }
 
         public object ConvertBack(object value,Type targetType,object parameter,CultureInfo culture)

--- a/BNails_MAUI/Views/RecuperarPwd.xaml.cs
+++ b/BNails_MAUI/Views/RecuperarPwd.xaml.cs
@@ -26,6 +26,6 @@ public partial class RecuperarPwd : ContentPage
 
     private async void VolverLogin_Tapped(object sender,TappedEventArgs e)
     {
-		await Shell.Current.GoToAsync("..");
+		await Shell.Current.GoToAsync("//Login");
     }
 }

--- a/BNails_MAUI/Views/ResetPwd.xaml
+++ b/BNails_MAUI/Views/ResetPwd.xaml
@@ -84,7 +84,7 @@
                     Text="Volver al Inicio de Sesión"
                     Style="{ StaticResource LabelInicio }">
                     <Label.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="VolverResetPwd_Tapped"/>
+                        <TapGestureRecognizer Tapped="VolverLogin_Tapped"/>
                     </Label.GestureRecognizers>
                 </Label>
 

--- a/BNails_MAUI/Views/ResetPwd.xaml.cs
+++ b/BNails_MAUI/Views/ResetPwd.xaml.cs
@@ -22,9 +22,9 @@ public partial class ResetPwd : ContentPage
         loadingPopup.BindingContext = BindingContext;
     }
 
-    private async void VolverResetPwd_Tapped(object sender,TappedEventArgs e)
+    private async void VolverLogin_Tapped(object sender,TappedEventArgs e)
     {
-        await Shell.Current.GoToAsync("..");
+        await Shell.Current.GoToAsync("//Login");
     }
 
     private void OnShowPasswordCheckBox_ResetPwd(object sender,CheckedChangedEventArgs e)

--- a/BNails_MAUI/Views/ValidarCodigo.xaml
+++ b/BNails_MAUI/Views/ValidarCodigo.xaml
@@ -40,10 +40,10 @@
                     TextTransform="Uppercase"
                     HorizontalOptions="Center"
                     TextDecorations="Underline"
-                    TextColor="Blue"
                     FontAttributes="Bold"
                     FontSize="Medium"
-                    IsVisible="{ Binding ReenviarCodigo }">
+                    IsEnabled="{ Binding UnenabledReenviarCodigoLbl }"
+                    TextColor="{Binding LabelTextColor}" >
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding ReenviarCodigoCommand}" />
                     </Label.GestureRecognizers>

--- a/BNails_MAUI/Views/ValidarCodigo.xaml.cs
+++ b/BNails_MAUI/Views/ValidarCodigo.xaml.cs
@@ -25,11 +25,6 @@ public partial class ValidarCodigo : ContentPage
 
     private async void VolverLogin_Tapped(object sender,TappedEventArgs e)
     {
-		await Shell.Current.GoToAsync("..");
-    }
-
-    private void ReenviarCodigo_Tapped(object sender,TappedEventArgs e)
-    {
-
+		await Shell.Current.GoToAsync("//Login");
     }
 }


### PR DESCRIPTION
La interfaz Validar Código permite ingresar hasta 2 veces el código de manera errónea, la tercera vez el botón Continuar se bloquea y se habilita el Label REENVIAR CÓDIGO para que el usuario lo pueda volver a solicitar. Lo mismo sucede si el código está vencido.